### PR TITLE
Upgrade to JDK 11 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk9-openj9
+FROM adoptopenjdk/openjdk11-openj9
 ADD springChat/target/spring-chat.jar spring-chat.jar
 EXPOSE 8085
 ENTRYPOINT ["java", "-jar", "spring-chat.jar"]


### PR DESCRIPTION
Users will almost certainly benefit from updating to the latest LTS major version of Java. This upgrade adds cgroup awareness, an essential feature for preventing OOM kills on a container platform; generally improves performance; and is much less likely to break existing code than the migration from JDK 8 to 9 did.